### PR TITLE
Document env file usage in Docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,29 @@ poetry install
 poetry run python moon/main.py
 ```
 
+### Environment variables
+
+The server reads its configuration from environment variables (optionally
+loaded via a local `.env` file). The most common settings are listed below:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `MCP_TRANSPORT` | Transport type used by the MCP server. | `streamable-http` |
+| `MCP_HOST` | Host interface the MCP server binds to. | `0.0.0.0` |
+| `QDRANT_URL` | Base URL of the Qdrant instance supplying context. | `https://657e9ff8-daa0-4003-bf76-c531e697932d.europe-west3-0.gcp.cloud.qdrant.io:6333` |
+| `QDRANT_API_KEY` | API key for the Qdrant instance. | _empty_ |
+| `QDRANT_TOP_K` | Number of top search results to return. | `10` |
+| `HF_TOKEN` | Hugging Face token used for embedding calls. | _empty_ |
+| `HF_MODEL` | Hugging Face embedding model identifier. | `BAAI/bge-m3` |
+
 ### Running with Docker
 
 ```bash
 docker build -t moon-mcp .
-docker run --rm -p 8181:8181 moon-mcp
+docker run --rm -p 8181:8181 --env-file .env moon-mcp
 ```
 
-The Docker image runs `python moon/main.py`, matching the local execution flow. Configure `MCP_HOST`, `MCP_PORT`, and other environment variables as needed when running the container.
+The Docker image runs `python moon/main.py`, matching the local execution flow. Update the `.env` file (or provide a different `--env-file`) to configure `MCP_HOST`, `MCP_PORT`, and other environment variables when running the container.
 
 ### Running tests
 


### PR DESCRIPTION
## Summary
- document how to supply environment variables to the container by referencing an `.env` file in the docker run example
- clarify that the `.env` file can be adjusted or replaced when configuring the container

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69115725cc288332b701d181d5f48080)